### PR TITLE
Merge POC into maidsafe repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+env:
+  global:
+    - RUST_BACKTRACE=1
+    - PATH=$PATH:$HOME/.cargo/bin
+os:
+  - linux
+  - osx
+language: rust
+rust:
+  - stable
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+sudo: false
+branches:
+  only:
+    - master
+cache:
+  cargo: true
+before_script:
+  - (which cargo-install-update && cargo install-update cargo-update) || cargo install cargo-update
+  - (which rustfmt && cargo install-update rustfmt) || cargo install rustfmt
+  - (which cargo-prune && cargo install-update cargo-prune) || cargo install cargo-prune
+script:
+  - if [ "${TRAVIS_RUST_VERSION}" = stable ]; then
+      (
+        set -x;
+        cargo fmt -- --write-mode=diff &&
+        cargo test  --verbose --release
+      );
+    fi
+  - curl -sSL https://github.com/maidsafe/QA/raw/master/bash_scripts/travis/run_clippy.sh | bash
+before_cache:
+  - cargo prune

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,25 @@ version = "0.0.1"
 
 [dependencies]
 clippy = { version = "=0.0.99", optional = true }
+error-chain = "0.7.1"
+libc  = { version= "0.2", optional = true }
+
+[dev-dependencies]
+rand = "0.3.0"
+
+
+[target.'cfg(target_os = "windows")'.dependencies]
+winreg = "0.4"
+
+
+[target.'cfg(target_os = "macos")'.dependencies]
+libc  = "0.2"
 
 [lib]
 crate_type = ["staticlib", "rlib", "cdylib"]
 name = "system_uri"
+
+[features]
+
+default = ["ffi"]
+ffi = ["libc"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
 # system_uri
+
 Desktop System App URI registration handler 
+
+**Maintainer:** Spandan Sharma (spandan.sharma@maidsafe.net)
+
+|Crate|Linux/OS X|Windows|Coverage|Issues|
+|:---:|:--------:|:-----:|:------:|:----:|
+|[![](http://meritbadge.herokuapp.com/system_uri)](https://crates.io/crates/system_uri)|[![Build Status](https://travis-ci.org/maidsafe/system_uri.svg?branch=master)](https://travis-ci.org/maidsafe/system_uri)|[![Build status](https://ci.appveyor.com/api/projects/status/c61jthx04us5j57j/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/system_uri/branch/master)|[![Coverage Status](https://coveralls.io/repos/maidsafe/system_uri/badge.svg?branch=master)](https://coveralls.io/r/maidsafe/system_uri?branch=master)|[![Stories in Ready](https://badge.waffle.io/maidsafe/system_uri.png?label=ready&title=Ready)](https://waffle.io/maidsafe/system_uri)|
+
+
+| [API Docs - master branch](http://docs.maidsafe.net/system_uri/master) | [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
+|:------:|:-------:|:-------:|:-------:|
+
+
+## Test Instructions
+
+`system_uri` bridges requests for the three major desktop platforms to register URI-scheme handlers and open URIs external through one simple interface. As this only works in tight integration with the system it is running on, this crate doesn't come with unittest but integration test through examples.
+
+To use it with the Mock:
+```
+cargo build
+cargo run --example test
+```
+
+## Configuration
+
+If you don't need the FFI-interface, you can disable it by disabeling the `ffi`-feature in your `cargo.toml` like so:
+
+```
+[dependencies.system_uri]
+version = "*"
+default-features = false
+```
+
+## License
+
+Licensed under either of
+
+* the MaidSafe.net Commercial License, version 1.0 or later ([LICENSE](LICENSE))
+* the General Public License (GPL), version 3 ([COPYING](COPYING) or http://www.gnu.org/licenses/gpl-3.0.en.html)
+
+at your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the
+work by you, as defined in the MaidSafe Contributor Agreement, version 1.1 ([CONTRIBUTOR]
+(CONTRIBUTOR)), shall be dual licensed as above, and you agree to be bound by the terms of the
+MaidSafe Contributor Agreement, version 1.1.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+environment:
+  global:
+    RUST_BACKTRACE: 1
+  matrix:
+    - RUST_VERSION: stable
+
+branches:
+  only:
+    - master
+
+clone_depth: 1
+
+install:
+  - ps: |
+        $url = "https://github.com/maidsafe/QA/raw/master/Powershell%20Scripts/AppVeyor"
+        cmd /c curl -fsSL -o "Install Rustup.ps1" "$url/Install%20Rustup.ps1"
+        . ".\Install Rustup.ps1"
+
+platform:
+  - x86
+  - x64
+
+configuration:
+  - Release
+
+build_script:
+  - cargo rustc --verbose --release -- --test -Zno-trans
+
+test_script:
+  - cargo test --verbose --release

--- a/examples/open.rs
+++ b/examples/open.rs
@@ -1,0 +1,34 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net
+// Commercial License, version 1.0 or later, or (2) The General Public License
+// (GPL), version 3, depending on which licence you accepted on initial access
+// to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project
+// generally, you agree to be bound by the terms of the MaidSafe Contributor
+// Agreement, version 1.0.
+// This, along with the Licenses can be found in the root directory of this
+// project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network
+// Software distributed under the GPL Licence is distributed on an "AS IS"
+// BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+//
+// Please review the Licences for the specific language governing permissions
+// and limitations relating to use of the SAFE Network Software.
+
+extern crate system_uri;
+
+use std::env;
+use system_uri::open;
+
+fn main() {
+    if let Some(url) = env::args().skip(1).next() {
+        println!("Trying to open {}", url);
+        let _ = open(url);
+    } else {
+        println!("Please specify your URL")
+    }
+}

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,0 +1,86 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net
+// Commercial License, version 1.0 or later, or (2) The General Public License
+// (GPL), version 3, depending on which licence you accepted on initial access
+// to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project
+// generally, you agree to be bound by the terms of the MaidSafe Contributor
+// Agreement, version 1.0.
+// This, along with the Licenses can be found in the root directory of this
+// project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network
+// Software distributed under the GPL Licence is distributed on an "AS IS"
+// BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+//
+// Please review the Licences for the specific language governing permissions
+// and limitations relating to use of the SAFE Network Software.
+
+extern crate system_uri;
+extern crate rand;
+
+use rand::Rng;
+use std::env;
+use std::process::exit;
+use std::{thread, time};
+
+use system_uri::{App, install, open, SystemUriError};
+
+fn install_and_open() -> Result<(), SystemUriError> {
+    let mut rng = rand::thread_rng();
+    let exec = String::from(std::env::current_exe().unwrap().to_str().unwrap());
+    let app = App::new("net.maidsafe.example".to_string(),
+                       "MaidSafe".to_string(),
+                       "Example".to_string(),
+                       exec,
+                       None);
+    let schema = format!("testschema{}", rng.gen::<u32>());
+
+    println!("Installing ourselves under {}", schema);
+
+
+    install(app, vec![schema.clone()]).and_then(|()| {
+
+        println!("Install succeeded 😄");
+
+        println!("Trying to open {}:test", schema);
+
+        open(format!("{}:test", schema)).and_then(|()| {
+            println!("Open succeeded 😄, everything is fine 🎉!");
+            Ok(())
+        })
+    })
+}
+
+fn main() {
+    if let Some(url) = env::args().skip(1).next() {
+        println!("Being started with {} as first parameter. Yay 🎉. Closing in 3",
+                 url);
+        thread::sleep(time::Duration::from_secs(1));
+        println!("2");
+        thread::sleep(time::Duration::from_secs(1));
+        println!("1");
+        thread::sleep(time::Duration::from_secs(1));
+        println!("Good bye!");
+        exit(0);
+    }
+
+    if let Err(ref e) = install_and_open() {
+        println!("error: {}", e);
+
+        for e in e.iter().skip(1) {
+            println!("caused by: {}", e);
+        }
+
+        // The backtrace is not always generated. Try to run this example
+        // with `RUST_BACKTRACE=1`.
+        if let Some(backtrace) = e.backtrace() {
+            println!("backtrace: {:?}", backtrace);
+        }
+
+        ::std::process::exit(1);
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,54 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net
+// Commercial License, version 1.0 or later, or (2) The General Public License
+// (GPL), version 3, depending on which licence you accepted on initial access
+// to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project
+// generally, you agree to be bound by the terms of the MaidSafe Contributor
+// Agreement, version 1.0.
+// This, along with the Licenses can be found in the root directory of this
+// project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network
+// Software distributed under the GPL Licence is distributed on an "AS IS"
+// BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+//
+// Please review the Licences for the specific language governing permissions
+// and limitations relating to use of the SAFE Network Software.
+
+
+#[derive(Debug)]
+/// The internal structure for an App
+pub struct App {
+    /// our apps bundle_id
+    pub bundle_id: String,
+    /// path to execute, including optional parameters
+    pub exec: String,
+    /// What's the vendor?
+    pub vendor: String,
+    /// the display name of the application
+    pub name: String,
+    /// an optional icon, only supported on some platforms
+    pub icon: Option<String>,
+}
+
+impl App {
+    /// create a new app
+    pub fn new(bundle_id: String,
+               vendor: String,
+               name: String,
+               exec: String,
+               icon: Option<String>)
+               -> Self {
+        App {
+            bundle_id: bundle_id,
+            name: name,
+            vendor: vendor,
+            exec: exec,
+            icon: icon,
+        }
+    }
+}

--- a/src/ffi/helper.rs
+++ b/src/ffi/helper.rs
@@ -1,0 +1,34 @@
+// Copyright 2015 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+// based on https://github.com/maidsafe/safe_core/blob/master/src/ffi/helper.rs
+
+use libc::int32_t;
+use std;
+use std::error::Error;
+use std::panic;
+use std::slice;
+use super::super::SystemUriError;
+
+pub unsafe fn c_utf8_to_str(ptr: *const u8, len: usize) -> Result<&'static str, SystemUriError> {
+    std::str::from_utf8(slice::from_raw_parts(ptr, len))
+        .map_err(|error| SystemUriError::from(error.description()))
+}
+
+pub fn catch_unwind_i32<F: FnOnce() -> int32_t>(f: F) -> int32_t {
+    panic::catch_unwind(panic::AssertUnwindSafe(f)).unwrap_or(1)
+}

--- a/src/ffi/macros.rs
+++ b/src/ffi/macros.rs
@@ -1,0 +1,36 @@
+// Copyright 2015 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+// from https://github.com/maidsafe/safe_core/blob/master/src/ffi/macros.rs
+
+macro_rules! ffi_try {
+    ($result:expr) => {
+        match $result {
+            Ok(value)  => value,
+            Err(error) => {
+                let decorator = ::std::iter::repeat('-').take(50).collect::<String>();
+                let err_str = format!("{:?}", error);
+                let err_code = 1;
+                // FIXME: this should become info! again, when this has been merged back
+                println!(
+                    "\nFFI cross-boundary error propagation:\n {}\n| **ERRNO: {}** {}\n {}\n\n",
+                    decorator, err_code, err_str, decorator);
+                return err_code
+            },
+        }
+    }
+}

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,0 +1,69 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net
+// Commercial License, version 1.0 or later, or (2) The General Public License
+// (GPL), version 3, depending on which licence you accepted on initial access
+// to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project
+// generally, you agree to be bound by the terms of the MaidSafe Contributor
+// Agreement, version 1.0.
+// This, along with the Licenses can be found in the root directory of this
+// project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network
+// Software distributed under the GPL Licence is distributed on an "AS IS"
+// BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+//
+// Please review the Licences for the specific language governing permissions
+// and limitations relating to use of the SAFE Network Software.
+
+#![allow(unsafe_code)]
+
+#[macro_use]
+mod macros;
+mod helper;
+
+use libc::int32_t;
+use super::{App, open as rust_open, install as rust_install};
+
+#[no_mangle]
+/// open the given URI on this system
+pub unsafe extern "C" fn open(uri: *const u8, uri_len: usize) -> int32_t {
+    helper::catch_unwind_i32(|| {
+        ffi_try!(rust_open(ffi_try!(helper::c_utf8_to_str(uri, uri_len)).to_owned()
+            ).and_then(|()| Ok(0)))
+    })
+}
+
+#[no_mangle]
+/// install the given App definition for each scheme URI on the system
+/// schemes are a comma delimited list of schemes
+pub unsafe extern "C" fn install(bundle_id: *const u8,
+                                 bundle_id_len: usize,
+                                 exec: *const u8,
+                                 exec_len: usize,
+                                 vendor: *const u8,
+                                 vendor_len: usize,
+                                 name: *const u8,
+                                 name_len: usize,
+                                 icon: *const u8,
+                                 icon_len: usize,
+                                 schemes: *const u8,
+                                 schemes_len: usize)
+                                 -> int32_t {
+    helper::catch_unwind_i32(|| {
+        let app = App::new(ffi_try!(helper::c_utf8_to_str(bundle_id, bundle_id_len)).to_owned(),
+                           ffi_try!(helper::c_utf8_to_str(exec, exec_len)).to_owned(),
+                           ffi_try!(helper::c_utf8_to_str(vendor, vendor_len)).to_owned(),
+                           ffi_try!(helper::c_utf8_to_str(name, name_len)).to_owned(),
+                           Some(ffi_try!(helper::c_utf8_to_str(icon, icon_len)).to_owned()));
+
+        let schemes = ffi_try!(helper::c_utf8_to_str(schemes, schemes_len)).to_owned();
+        ffi_try!(rust_install(app, schemes.split(',')
+                     .map(|s| s.to_string())
+                     .collect::<Vec<String>>())
+                .and_then(|()| Ok(0)))
+    })
+}

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,0 +1,89 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net
+// Commercial License, version 1.0 or later, or (2) The General Public License
+// (GPL), version 3, depending on which licence you accepted on initial access
+// to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project
+// generally, you agree to be bound by the terms of the MaidSafe Contributor
+// Agreement, version 1.0.
+// This, along with the Licenses can be found in the root directory of this
+// project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network
+// Software distributed under the GPL Licence is distributed on an "AS IS"
+// BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+//
+// Please review the Licences for the specific language governing permissions
+// and limitations relating to use of the SAFE Network Software.
+
+
+use std::env;
+use std::ascii::AsciiExt;
+use std::fs::{create_dir_all, File};
+use std::io::Write;
+use std::process::Command;
+use std::path::PathBuf;
+
+use errors::*;
+use app::App;
+
+/// Open a given URI on Linux systems
+pub fn open(uri: String) -> Result<()> {
+    let status = Command::new("xdg-open").arg(uri)
+        .status()
+        .chain_err(|| "Could not execute xdg-open")?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("Executing xdg-open failed. See terminal output for errors.").into())
+    }
+
+}
+
+/// register the given App for the given schemes on Linux
+pub fn install(app: App, schemes: Vec<String>) -> Result<()> {
+    let home = env::home_dir().ok_or("Home directory not found")?;
+    let ascii_name = format!("{}-{}",
+                             app.vendor.as_str().to_ascii_lowercase(),
+                             app.name.as_str().to_ascii_lowercase());
+
+    let mut desktop_target = PathBuf::new();
+    desktop_target.push(home);
+    desktop_target.push(".local");
+    desktop_target.push("share");
+    desktop_target.push("applications");
+
+    let apps_dir = desktop_target.clone();
+
+    create_dir_all(apps_dir.clone()).chain_err(|| "Could not create app directory")?;
+
+    desktop_target.push(ascii_name + ".desktop");
+    let mut f =
+        File::create(desktop_target.as_path()).chain_err(|| "Could not create app desktop file")?;
+    let schemes_list = schemes.iter()
+        .map(|s| format!("x-scheme-handler/{};", s))
+        .collect::<Vec<String>>()
+        .join("");
+
+    f.write_fmt(format_args!(include_str!("./template.desktop"),
+                                name = app.name,
+                                exec = app.exec,
+                                // app.icon.unwrap_or("".to_string()),
+                                mime_types = schemes_list))
+        .chain_err(|| " Could not write app desktop file")?;
+
+    let status = Command::new("update-desktop-database").arg(apps_dir)
+        .status()
+        .chain_err(|| "Could not run update-desktop-database")?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("Executing update-desktop-database failed. See terminal output for errors.")
+            .into())
+    }
+}

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,0 +1,94 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net
+// Commercial License, version 1.0 or later, or (2) The General Public License
+// (GPL), version 3, depending on which licence you accepted on initial access
+// to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project
+// generally, you agree to be bound by the terms of the MaidSafe Contributor
+// Agreement, version 1.0.
+// This, along with the Licenses can be found in the root directory of this
+// project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network
+// Software distributed under the GPL Licence is distributed on an "AS IS"
+// BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+//
+// Please review the Licences for the specific language governing permissions
+// and limitations relating to use of the SAFE Network Software.
+
+
+use std::process::Command;
+use libc;
+
+use errors::*;
+use app::App;
+
+#[repr(C)]
+struct __CFString(libc::c_void);
+type CFStringRef = *const __CFString;
+
+type CFAllocatorRef = *const libc::c_void;
+type CFIndex = libc::c_long;
+type CFStringEncoding = u32;
+
+
+#[link(name = "CoreFoundation", kind = "framework")]
+extern "C" {
+    static kCFAllocatorDefault: CFAllocatorRef;
+    static kCFAllocatorNull: CFAllocatorRef;
+    fn CFStringCreateWithBytes(alloc: CFAllocatorRef,
+                               bytes: *const u8,
+                               numBytes: CFIndex,
+                               encoding: CFStringEncoding,
+                               isExternalRepresentation: u8,
+                               contentsDeallocator: CFAllocatorRef)
+                               -> CFStringRef;
+}
+
+
+#[link(name = "CoreServices", kind = "framework")]
+extern "C" {
+    fn LSSetDefaultHandlerForURLScheme(scheme: CFStringRef, bundle_id: CFStringRef);
+}
+
+
+// helper to hand over strings to macos
+fn convert_to_cfstring(content: &str) -> CFStringRef {
+    unsafe {
+        CFStringCreateWithBytes(kCFAllocatorDefault,
+                                content.as_ptr(),
+                                content.len() as CFIndex,
+                                0x08000100 as CFStringEncoding,
+                                false as u8,
+                                kCFAllocatorNull)
+    }
+}
+
+
+/// Open a given URI on MacOSX systems
+pub fn open(uri: String) -> Result<()> {
+    Command::new("open").arg(uri)
+        .status()
+        .chain_err(|| "Could not execute open")?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("Executing open failed. See terminal output for errors.").into())
+    }
+}
+
+/// register the given App for the given schemes on MacOSX
+pub fn install(app: App, schemes: Vec<String>) -> Result<()> {
+    let bundle_id = convert_to_cfstring(app.bundle_id.as_str());
+    for scheme in schemes {
+        // FIXME: do we have any way to learn this failed?
+        unsafe {
+            LSSetDefaultHandlerForURLScheme(convert_to_cfstring(scheme.as_str()), bundle_id);
+        }
+    }
+    Ok(())
+}

--- a/src/template.desktop
+++ b/src/template.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name={name}
+Exec={exec} %u
+Terminal=false
+MimeType={mime_types}
+NoDisplay=true

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,0 +1,64 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net
+// Commercial License, version 1.0 or later, or (2) The General Public License
+// (GPL), version 3, depending on which licence you accepted on initial access
+// to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project
+// generally, you agree to be bound by the terms of the MaidSafe Contributor
+// Agreement, version 1.0.
+// This, along with the Licenses can be found in the root directory of this
+// project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network
+// Software distributed under the GPL Licence is distributed on an "AS IS"
+// BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+//
+// Please review the Licences for the specific language governing permissions
+// and limitations relating to use of the SAFE Network Software.
+
+
+extern crate winreg;
+
+use std::path::Path;
+use std::process::Command;
+use self::winreg::RegKey;
+use self::winreg::enums::HKEY_CURRENT_USER;
+
+use errors::*;
+use app::App;
+
+// as described at https://msdn.microsoft.com/en-us/library/aa767914(v=vs.85).aspx
+/// register the given App for the given schemes on Windows
+pub fn install(app: App, schemes: Vec<String>) -> Result<()> {
+    // but we can't write on root, we'll have to do it for the curent user only
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    for protocol in schemes {
+        let base_path = Path::new("Software").join("Classes").join(protocol);
+        let key = hkcu.create_subkey(&base_path).chain_err(|| "could not create subkey")?;
+        // set our app name as the for reference
+        key.set_value("", &app.name).chain_err(|| "could not set app name key")?;
+        //
+        key.set_value("URL Protocol", &"").chain_err(|| "could set url protocol")?;
+
+        let command_key = hkcu.create_subkey(&base_path.join("shell")
+                .join("open")
+                .join("command"))
+            .chain_err(|| "could not execute open")?;
+        command_key.set_value("", &format!("\"{}\" \"%1\"", app.exec))
+            .chain_err(|| "could not create subkey")?
+    }
+    Ok(())
+}
+
+/// Open a given URI on Windows
+pub fn open(uri: String) -> Result<()> {
+    let _ = Command::new("explorer").arg(uri)
+        .status()
+        .chain_err(|| "Could not open 'explorere")?;
+    // 'explorer' always comes back with a bad error code :(
+    // but neither 'start' nor 'cmd /c start' seem to work...
+    Ok(())
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,43 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net
+// Commercial License, version 1.0 or later, or (2) The General Public License
+// (GPL), version 3, depending on which licence you accepted on initial access
+// to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project
+// generally, you agree to be bound by the terms of the MaidSafe Contributor
+// Agreement, version 1.0.
+// This, along with the Licenses can be found in the root directory of this
+// project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network
+// Software distributed under the GPL Licence is distributed on an "AS IS"
+// BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+//
+// Please review the Licences for the specific language governing permissions
+// and limitations relating to use of the SAFE Network Software.
+
+extern crate system_uri;
+extern crate rand;
+
+use rand::Rng;
+
+use system_uri::{App, install, open};
+
+#[test]
+fn install_and_open() {
+    let mut rng = rand::thread_rng();
+    let exec = String::from(std::env::current_exe().unwrap().to_str().unwrap());
+    println!("{:}", exec);
+    let app = App::new("net.maidsafe.example".to_string(),
+                       "MaidSafe".to_string(),
+                       "Example".to_string(),
+                       exec,
+                       None);
+    let schema = format!("testschema{}", rng.gen::<u32>());
+
+    assert!(install(app, vec![schema.clone()]).is_ok());
+    assert!(open(format!("{}:test", schema)).is_ok());
+}


### PR DESCRIPTION
Merges the upstream maidsafe repo for the new location with the POC. Further more cleans up the repo and:

 - [x] adds proper licensing to all source files
 - [x] adds travis and appveyor setup (not yet working on mac)
 - [x] adds FFI interface
 - [x] fixes formatting for rustfmt and clippy

ref [Maid 1854](https://maidsafe.atlassian.net/browse/MAID-1854)