### PR TITLE
Replace FFIStrings with c_char

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -21,9 +21,9 @@
 
 #![allow(unsafe_code)]
 
-use ffi_utils::{ErrorCode, catch_unwind_error_code};
 use super::{App, install as rust_install, open as rust_open};
 use super::errors::*;
+use ffi_utils::{ErrorCode, catch_unwind_error_code};
 
 use libc::c_char;
 use std::ffi::CStr;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -21,15 +21,19 @@
 
 #![allow(unsafe_code)]
 
-use ffi_utils::{ErrorCode, FfiString, catch_unwind_error_code};
+use ffi_utils::{ErrorCode, catch_unwind_error_code};
 use super::{App, install as rust_install, open as rust_open};
 use super::errors::*;
 
+use libc::c_char;
+use std::ffi::CStr;
+
+
 /// open the given URI on this system
 #[no_mangle]
-pub unsafe extern "C" fn open(uri: FfiString) -> i32 {
+pub unsafe extern "C" fn open(uri: *const c_char) -> i32 {
     catch_unwind_error_code(|| {
-        let uri = uri.to_string()?;
+        let uri = (CStr::from_ptr(uri).to_str()?).to_owned();
         rust_open(uri)
     })
 }
@@ -37,21 +41,21 @@ pub unsafe extern "C" fn open(uri: FfiString) -> i32 {
 #[no_mangle]
 /// install the given App definition for each scheme URI on the system
 /// schemes are a comma delimited list of schemes
-pub unsafe extern "C" fn install(bundle: FfiString,
-                                 exec: FfiString,
-                                 vendor: FfiString,
-                                 name: FfiString,
-                                 icon: FfiString,
-                                 schemes: FfiString)
+pub unsafe extern "C" fn install(bundle: *const c_char,
+                                 exec: *const c_char,
+                                 vendor: *const c_char,
+                                 name: *const c_char,
+                                 icon: *const c_char,
+                                 schemes: *const c_char)
                                  -> i32 {
     catch_unwind_error_code(|| {
-        let app = App::new(bundle.to_string()?,
-                           exec.to_string()?,
-                           vendor.to_string()?,
-                           name.to_string()?,
-                           Some(icon.to_string()?));
+        let app = App::new((CStr::from_ptr(bundle).to_str()?).to_owned(),
+                           (CStr::from_ptr(exec).to_str()?).to_owned(),
+                           (CStr::from_ptr(vendor).to_str()?).to_owned(),
+                           (CStr::from_ptr(name).to_str()?).to_owned(),
+                           Some((CStr::from_ptr(icon).to_str()?).to_owned()));
 
-        let schemes = schemes.to_string()?;
+        let schemes = (CStr::from_ptr(schemes).to_str()?).to_owned();
 
         rust_install(app,
                      schemes.split(',')

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,6 @@ extern crate libc;
 extern crate xdg_basedir;
 
 #[cfg(feature = "ffi")]
-#[macro_use]
 extern crate ffi_utils;
 
 mod app;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 #[macro_use]
 extern crate error_chain;
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", feature="ffi"))]
 extern crate libc;
 
 #[cfg(target_os = "linux")]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -22,11 +22,11 @@
 
 extern crate winreg;
 
+use self::winreg::RegKey;
+use self::winreg::enums::HKEY_CURRENT_USER;
 use app::App;
 
 use errors::*;
-use self::winreg::RegKey;
-use self::winreg::enums::HKEY_CURRENT_USER;
 use std::path::Path;
 use std::process::Command;
 


### PR DESCRIPTION
With the FFIString taken out of ffi_utils, we, too, must convert
back to c_char based parameters. This PR implements that.