### PR TITLE
Fix stdout nulling for child processes on *nix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,9 @@ clone_depth: 1
 
 install:
   - ps: |
-        $url = "https://github.com/maidsafe/QA/raw/master/Powershell%20Scripts/AppVeyor"
-        cmd /c curl -fsSL -o "Install Rustup.ps1" "$url/Install%20Rustup.ps1"
-        . ".\Install Rustup.ps1"
+        $url = "https://github.com/maidsafe/QA/raw/master/appveyor/install_rustup.ps1"
+        Invoke-WebRequest $url -OutFile "install_rustup.ps1"
+        . ".\install_rustup.ps1"
 
 platform:
   - x86

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -27,12 +27,12 @@ use xdg_basedir::dirs::get_data_home;
 
 /// Open a given URI on Linux systems
 pub fn open(uri: String) -> Result<()> {
-    let status = Command::new("xdg-open")
+    let output = Command::new("xdg-open")
         .arg(uri)
-        .status()
+        .output()
         .chain_err(|| "Could not execute xdg-open")?;
 
-    if status.success() {
+    if output.status.success() {
         Ok(())
     } else {
         Err(("Executing xdg-open failed. See terminal output for errors.").into())

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -27,7 +27,8 @@ use xdg_basedir::dirs::get_data_home;
 
 /// Open a given URI on Linux systems
 pub fn open(uri: String) -> Result<()> {
-    let status = Command::new("xdg-open").arg(uri)
+    let status = Command::new("xdg-open")
+        .arg(uri)
         .status()
         .chain_err(|| "Could not execute xdg-open")?;
 
@@ -59,11 +60,12 @@ pub fn install(app: &App, schemes: &[String]) -> Result<()> {
 
     let apps_dir = desktop_target.clone();
 
-    create_dir_all(apps_dir.clone()).chain_err(|| "Could not create app directory")?;
+    create_dir_all(apps_dir.clone())
+        .chain_err(|| "Could not create app directory")?;
 
     desktop_target.push(ascii_name.clone());
-    let mut f =
-        File::create(desktop_target.as_path()).chain_err(|| "Could not create app desktop file")?;
+    let mut f = File::create(desktop_target.as_path())
+        .chain_err(|| "Could not create app desktop file")?;
     let schemes_list = schemes
         .iter()
         .map(|s| format!("x-scheme-handler/{}", s))
@@ -76,13 +78,15 @@ pub fn install(app: &App, schemes: &[String]) -> Result<()> {
                                 mime_types = schemes_list.join(";")))
         .chain_err(|| " Could not write app desktop file")?;
 
-    let status = Command::new("update-desktop-database").arg(apps_dir)
+    let status = Command::new("update-desktop-database")
+        .arg(apps_dir)
         .status()
         .chain_err(|| "Could not run update-desktop-database")?;
 
 
     for scheme in schemes_list {
-        let _ = Command::new("xdg-mime").arg("default")
+        let _ = Command::new("xdg-mime")
+            .arg("default")
             .arg(ascii_name.clone())
             .arg(scheme)
             .status()

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -67,12 +67,12 @@ fn convert_to_cfstring(content: &str) -> CFStringRef {
 
 /// Open a given URI on MacOSX systems
 pub fn open(uri: String) -> Result<()> {
-    let status = Command::new("open")
+    let output = Command::new("open")
         .arg(uri)
-        .status()
+        .output()
         .chain_err(|| "Could not execute open")?;
 
-    if status.success() {
+    if output.status.success() {
         Ok(())
     } else {
         Err(format!("Executing open failed. See terminal output for errors.").into())

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -67,7 +67,8 @@ fn convert_to_cfstring(content: &str) -> CFStringRef {
 
 /// Open a given URI on MacOSX systems
 pub fn open(uri: String) -> Result<()> {
-    let status = Command::new("open").arg(uri)
+    let status = Command::new("open")
+        .arg(uri)
         .status()
         .chain_err(|| "Could not execute open")?;
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -43,7 +43,8 @@ pub fn install(app: &App, schemes: &[String]) -> Result<()> {
 
         let command_key = hkcu.create_subkey(&base_path.join("shell").join("open").join("command"))
             .chain_err(|| "could not execute open")?;
-        command_key.set_value("", &format!("\"{}\" \"%1\"", app.exec))
+        command_key
+            .set_value("", &format!("\"{}\" \"%1\"", app.exec))
             .chain_err(|| "could not create subkey")?
     }
     Ok(())
@@ -51,7 +52,8 @@ pub fn install(app: &App, schemes: &[String]) -> Result<()> {
 
 /// Open a given URI on Windows
 pub fn open(uri: String) -> Result<()> {
-    let _ = Command::new("explorer").arg(uri)
+    let _ = Command::new("explorer")
+        .arg(uri)
         .status()
         .chain_err(|| "Could not open 'explorere")?;
     // 'explorer' always comes back with a bad error code :(


### PR DESCRIPTION
This causes EBADF (bad file descriptor) errors on Electron apps when they output info to the console. These apps don't expect stdout to be null, which is seemingly is the standard case for `Command` in stdlib. This can be fixed by capturing output from stdout expicitly, using `Command::output` instead of `Command::status`.