### PR TITLE
Use native ShellExecuteW for opening on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rand = "0.3.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.4"
+winapi = "0.2.8"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 xdg-basedir = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,6 @@ mod windows;
 #[cfg(target_os = "windows")]
 pub use windows::{install, open};
 
-
 #[cfg(target_os = "macos")]
 mod macos;
 #[cfg(target_os = "macos")]

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -41,10 +41,7 @@ pub fn open(uri: String) -> Result<()> {
 }
 
 fn clean_string(input: &str) -> String {
-    input
-        .replace(".", "")
-        .replace("/", "")
-        .to_ascii_lowercase()
+    input.replace(".", "").replace("/", "").to_ascii_lowercase()
 }
 
 /// register the given App for the given schemes on Linux

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -34,7 +34,10 @@ use std::path::Path;
 use std::ptr;
 
 fn to_wide_chars(s: &str) -> Vec<u16> {
-    OsStr::new(s).encode_wide().chain(Some(0).into_iter()).collect::<Vec<_>>()
+    OsStr::new(s)
+        .encode_wide()
+        .chain(Some(0).into_iter())
+        .collect::<Vec<_>>()
 }
 
 #[link(name = "shell32")]
@@ -67,7 +70,8 @@ pub fn install(app: &App, schemes: &[String]) -> Result<()> {
 
         let command_key = hkcu.create_subkey(&base_path.join("shell").join("open").join("command"))
             .chain_err(|| "could not execute open")?;
-        command_key.set_value("", &format!("\"{}\" \"%1\"", app.exec))
+        command_key
+            .set_value("", &format!("\"{}\" \"%1\"", app.exec))
             .chain_err(|| "could not create subkey")?
     }
     Ok(())

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -41,7 +41,7 @@ fn to_wide_chars(s: &str) -> Vec<u16> {
 }
 
 #[link(name = "shell32")]
-extern "C" {
+extern "system" {
     pub fn ShellExecuteW(hwnd: HWND,
                          lpOperation: LPCWSTR,
                          lpFile: LPCWSTR,


### PR DESCRIPTION
It is more reliabled than explorer, especially for older windows (<10) versions.