### PR TITLE
fix/Split every parameter of the exec command and enclose them in quotes

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -72,7 +72,10 @@ pub fn install(app: &App, schemes: &[String]) -> Result<()> {
         let command_key = hkcu.create_subkey(&base_path.join("shell").join("open").join("command"))
             .chain_err(|| "could not execute open")?;
         command_key
-            .set_value("", &format!("\"{}\" \"%1\"", app.exec))
+            .set_value(
+                "",
+                &format!("\"{}\" \"%1\"", app.exec.replace(" ", "\" \"")),
+            )
             .chain_err(|| "could not create subkey")?
     }
     Ok(())


### PR DESCRIPTION
Windows needs all parameters to be split and enclosed in quotes. In dev mode, when the app's foder is provided as first parameter to the electron executable, and the URL is the second one, the command doesn't work unless each param has its own quotes.