### PR TITLE
Version change to 0.4.0;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # System URI - Change Log
 
+## [0.4.0]
+- Use pointers instead of passing plain structures (e.g. for `FfiResult`)
+- Change the `install` function to take the `exec` command as an array of arguments rather than string
+- Use rust 1.22.1 stable / 2017-12-03 nightly
+- rustfmt 0.9.0 and clippy-0.0.175
+
 ## [0.3.0]
 - Rename `open` to `open_uri`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "system_uri"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi_utils 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "system_uri"
 readme = "README.md"
 repository = "https://github.com/maidsafe/system_uri"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 error-chain = "0.11.0-rc"


### PR DESCRIPTION
- Use pointers instead of passing plain structures (e.g. for `FfiResult`)
- Change the `install` function to take the `exec` command as an array of arguments rather than string
- Use rust 1.22.1 stable / 2017-12-03 nightly
- rustfmt 0.9.0 and clippy-0.0.175