### PR TITLE
[MAID-3107] chore/ci: update scripts to Rust stable 1.28.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 vars:
-  - &stable "1.26.2"
-  - &stable-i686 "1.26.2-i686-unknown-linux-gnu"
-  - &nightly "nightly-2018-06-10"
+  - &stable "1.28.0"
+  - &stable-i686 "1.28.0-i686-unknown-linux-gnu"
+  - &nightly "nightly-2018-07-07"
 env:
   global:
     - RUST_BACKTRACE=1
     - PATH=$PATH:$HOME/.cargo/bin
-    - RUST_STABLE=1.26.2
-    - RUST_NIGHTLY=nightly-2018-06-10
-    - RUST_RUSTFMT=0.8.2
-    - RUST_CLIPPY=0.0.207
+    - RUST_STABLE=1.28.0
+    - RUST_NIGHTLY=nightly-2018-07-07
+    - RUST_RUSTFMT=0.99.2
+    - RUST_CLIPPY=0.0.212
 language: rust
 addons:
   apt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   global:
     RUST_BACKTRACE: 1
   matrix:
-    - RUST_STABLE: &stable "1.26.2"
+    - RUST_STABLE: &stable "1.28.0"
     - RUST_TOOLCHAIN: *stable
 
 branches:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,30 +23,66 @@
 // https://github.
 // com/feross/webtorrent-desktop/blob/4bb2056bc9c1a421815b97d03ffed512575dfde0/src/main/handlers.js
 #![forbid(
-    exceeding_bitshifts, mutable_transmutes, no_mangle_const_items, unknown_crate_types, warnings
+    exceeding_bitshifts,
+    mutable_transmutes,
+    no_mangle_const_items,
+    unknown_crate_types,
+    warnings
 )]
 #![deny(
-    bad_style, deprecated, improper_ctypes, missing_docs, non_shorthand_field_patterns,
-    overflowing_literals, plugin_as_library, private_no_mangle_fns, private_no_mangle_statics,
-    stable_features, unconditional_recursion, unknown_lints, unsafe_code, unused, unused_allocation,
-    unused_attributes, unused_comparisons, unused_features, unused_parens, while_true
+    bad_style,
+    deprecated,
+    improper_ctypes,
+    missing_docs,
+    non_shorthand_field_patterns,
+    overflowing_literals,
+    plugin_as_library,
+    private_no_mangle_fns,
+    private_no_mangle_statics,
+    stable_features,
+    unconditional_recursion,
+    unknown_lints,
+    unsafe_code,
+    unused,
+    unused_allocation,
+    unused_attributes,
+    unused_comparisons,
+    unused_features,
+    unused_parens,
+    while_true
 )]
 #![warn(
-    trivial_casts, trivial_numeric_casts, unused_extern_crates, unused_import_braces,
-    unused_qualifications, unused_results
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    unused_results
 )]
 // TODO: Remove `renamed_and_removed_lints` once
 // https://github.com/rust-lang-nursery/error-chain/pull/246 has been fixed.
 #![allow(
-    box_pointers, missing_copy_implementations, missing_debug_implementations,
-    variant_size_differences, renamed_and_removed_lints
+    box_pointers,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    variant_size_differences,
+    renamed_and_removed_lints
 )]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 #![cfg_attr(
-    feature = "clippy", deny(clippy, unicode_not_nfc, wrong_pub_self_convention, option_unwrap_used)
+    feature = "clippy",
+    deny(
+        clippy,
+        unicode_not_nfc,
+        wrong_pub_self_convention,
+        option_unwrap_used
+    )
 )]
-#![cfg_attr(feature = "clippy", allow(use_debug, too_many_arguments, needless_return))]
+#![cfg_attr(
+    feature = "clippy",
+    allow(use_debug, too_many_arguments, needless_return)
+)]
 // `error_chain!` can recurse deeply
 #![recursion_limit = "1024"]
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -72,8 +72,7 @@ pub fn install(app: &App, schemes: &[String]) -> Result<()> {
                 format!("x-scheme-handler/{}", s.to_lowercase())
             }
             None => format!("x-scheme-handler/{}", s),
-        })
-        .collect::<Vec<String>>();
+        }).collect::<Vec<String>>();
 
     f.write_fmt(format_args!(
         include_str!("./template.desktop"),


### PR DESCRIPTION
nightly to 2018-07-07
clippy to 0.0.212
rustfmt to 0.99.2